### PR TITLE
fix: disable browser behaviours on search bar input

### DIFF
--- a/src/components/search-bar.component.ts
+++ b/src/components/search-bar.component.ts
@@ -20,6 +20,10 @@ class SearchBar extends HTMLElement {
     this.input.type = 'text'
     this.input.placeholder = 'Search by campus, building, or room...'
     this.input.name = 'search'
+    this.input.autocapitalize = 'off'
+    this.input.autocomplete = 'off'
+    this.input.autocorrect = false
+    this.input.spellcheck = false
 
     this.input.classList.add(
       'bg-white',


### PR DESCRIPTION
In addition to autocomplete, this PR explicitly disables autocapitalize, autocorrect, and spellcheck.