### PR TITLE
Clear search button doesnt appear on selection via map

### DIFF
--- a/src/components/search-bar.component.ts
+++ b/src/components/search-bar.component.ts
@@ -60,6 +60,7 @@ export default class SearchBar extends HTMLElement implements Subscriber {
 
     this.dropdown = new SearchDropdown()
 
+    this.input.addEventListener('focus', () => this.input.select())
     this.input.addEventListener('input', () => this.handleInput())
     document.addEventListener('keydown', this.handleKeyDown.bind(this))
     document.addEventListener('click', (e) => {


### PR DESCRIPTION
- Reveals search bar button when search bar is populated via map-click selection
- Introduces select search bar query text on search bar focus